### PR TITLE
Support kubeconform for verification

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 
 func main() {
 	var (
+		// TODO: Expose flag for policy dir
 		fixtureDir = flag.String("fixtures-dir", "fixtures", "Directory containing fixtures e.g. values files to be tested. Relative to chart directory.")
 		preserve   = flag.Bool("preserve", false, "Log the temporary directory instead of deleting it")
 	)
@@ -108,12 +109,22 @@ func run(srcChart, fixturesDir string, preserve bool) error {
 	}
 
 	for _, dir := range outputDirs {
-		out, err := exec.Command("conftest", "test", "--policy", filepath.Join(chartDir, "policy"), dir).CombinedOutput()
+		// TODO: Parse structured comments and pass to conftest
+		out, err := exec.Command("conftest", "test", "--output=json", "--policy", filepath.Join(chartDir, "policy"), dir).CombinedOutput()
 		if err != nil {
 			failed = true
 		}
 		fmt.Fprintf(os.Stdout, "Conftest output (%s):\n%s\n\n", filepath.Base(dir), string(out))
+
+		// TODO: Pass through -schema-location?
+		out, err = exec.Command("kubeconform", "-summary", "-n=16", "-output=json", dir).CombinedOutput()
+		if err != nil {
+			failed = true
+		}
+		fmt.Fprintf(os.Stdout, "Kubeconform output (%s):\n%s\n\n", filepath.Base(dir), string(out))
 	}
+
+	// TODO: Parse json output, format nicely for console
 
 	if failed {
 		return fmt.Errorf("test failure")


### PR DESCRIPTION
The chart will now be rendered for each fixture and passed to kubeconform for validation against known k8s openapi schemas.